### PR TITLE
Tech for building templates for coverage reports

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "bh": ">= 1.0.0 < 4.0.0"
   },
   "dependencies": {
+    "istanbul": "^0.3.2",
     "vow": "0.4.5"
   },
   "devDependencies": {

--- a/techs/bh-server-coverage.js
+++ b/techs/bh-server-coverage.js
@@ -1,0 +1,40 @@
+/**
+ * bh-server-coverage
+ * =================
+ *
+ * Склеивает *bh*-файлы по deps'ам в виде `?.bh.js`, инструментируя их при помощи istanbul.
+ * Предназначен для сборки статистики покрытия тестами серверного BH-кода.
+ * Предполагается, что в *bh*-файлах не используется `require`.
+ *
+ * **Опции**
+ *
+ * * *String* **target** — Результирующий таргет. По умолчанию — `?.bh.js`.
+ * * *String* **filesTarget** — files-таргет, на основе которого получается список исходных файлов
+ *   (его предоставляет технология `files`). По умолчанию — `?.files`.
+ * * *String* **sourceSuffixes** — суффиксы файлов, по которым строится `files`-таргет. По умолчанию — ['bh'].
+ * * *String* **jsAttrName** — атрибут блока с параметрами инициализации. По умолчанию — `onclick`.
+ * * *String* **jsAttrScheme** — Cхема данных для параметров инициализации. По умолчанию — `js`.
+ * *                             Форматы:
+ * *                                `js` — Получаем `return { ... }`.
+ * *                                `json` — JSON-формат. Получаем `{ ... }`.
+ *
+ * **Пример**
+ *
+ * ```javascript
+ * nodeConfig.addTech(require('enb-bh/techs/bh-server-coverage'));
+ * ```
+ */
+var path = require('path');
+var istanbul = require('istanbul');
+var instrumenter = new istanbul.Instrumenter({
+    coverageVariable: '__bh_coverage__'
+});
+
+module.exports = require('./bh-server-include').buildFlow()
+    .methods({
+        _preConcatFile: function (file, content) {
+            var filePath = path.relative(process.cwd(), file.fullname);
+            return instrumenter.instrumentSync(content, filePath);
+        }
+    })
+    .createTech();

--- a/techs/bh-server-include.js
+++ b/techs/bh-server-include.js
@@ -43,11 +43,17 @@ module.exports = require('enb/lib/build-flow').create()
     .saveCache(function (cache) {
         cache.cacheFileInfo('bh-file', this._bhFile);
     })
+    .methods({
+        _preConcatFile: function (file, content) {
+            return content;
+        }
+    })
     .builder(function (bhFiles) {
         var node = this.node;
         var dependencies = {};
         var jsAttrName = this._jsAttrName;
         var jsAttrScheme = this._jsAttrScheme;
+        var _this = this;
         return vow.all([
             vfs.read(this._bhFile, 'utf8').then(function (data) {
                 return data;
@@ -55,8 +61,9 @@ module.exports = require('enb/lib/build-flow').create()
             vow.all(bhFiles.map(function (file) {
                 return vfs.read(file.fullname, 'utf8').then(function (data) {
                     var relPath = node.relativePath(file.fullname);
+                    var processed = bhClientProcessor.process(data);
                     return '// begin: ' + relPath + '\n' +
-                        bhClientProcessor.process(data) + '\n' +
+                        _this._preConcatFile(file, processed) + '\n' +
                         '// end: ' + relPath + '\n';
                 });
             })).then(function (sr) {


### PR DESCRIPTION
Tech is based 'bh-server-include'. 'bh-server-include' is modified
to allow derived technologies to modify code before it concatenated
with other. `bh-server-coverage` does this to instrument template code
with istanbul.

Tech does not produce actual report, it only collects data into
`__bh-coverage__` variable. Some other code is needed to convert this
data into one of supported by istanbul reports.

Pull request to `enb-bem-tmpl-specs` to produce the report is to follow.

@andrewblond @scf2k @arikon 
