### PR TITLE
В версии 0.4.0 стал неверно собираться клиентский bh с использованием bh-client-module

### DIFF
--- a/lib/bh-client-processor.js
+++ b/lib/bh-client-processor.js
@@ -29,7 +29,7 @@ module.exports = {
         this._defineModule('bh', file, dependencies, bhEngine, inputSources, jsAttrName, jsAttrScheme, true);
 
         if (mimic) {
-            this._defineModule(mimic, file, {bh: 'bh'});
+            this._defineModule(mimic, file, { bh: 'bh' });
         }
 
         return file;
@@ -111,7 +111,8 @@ module.exports = {
      * @param {Boolean} shouldConcatFile if set concat standalone module contents
      * @returns {Object} enb-source-map/lib/file instance
      */
-    _defineModule: function (name, file, dependencies, bhEngine, inputSources, jsAttrName, jsAttrScheme, shouldConcatFile) {
+    _defineModule: function (name, file, dependencies, bhEngine, inputSources, jsAttrName,
+                                jsAttrScheme, shouldConcatFile) {
         var libNames,
             depNames;
 


### PR DESCRIPTION
В версии 0.4.0 поломалась сборка с использованием технологии bh-client-module и dependencies.
В версии 0.2.3 собранный файл выглядел примерно так:

``` javascript
modules.define('bh', ["module1"], function(provide, module1) {
  var BH = ...
  var bh = new BH();
    bh.setOptions({
        jsAttrName: 'data-bem',
        jsAttrScheme: 'json'
    });
    bh.lib.module1 = module1;

  bh.match(...);
  bh.match(...);
  bh.match(...);

  provide(bh);
});
```

В версии 0.4.0 так:

``` javascript
(function() {
  var BH = ...
  var bh = new BH();
    bh.setOptions({
        jsAttrName: 'data-bem',
        jsAttrScheme: 'json'
    });
    bh.lib.module1 = module1;

  bh.match(...);
  bh.match(...);
  bh.match(...);

  modules.define('bh', ["module1"], function(provide, module1) {
    provide(bh);
  });
})();
```

Это приводит к тому, что может быть ошибка `module1 is not defined`, поскольку он не загружен на момент выполнения кода `bh.lib.module1 = module1`. Этот пулреквест восстанавливает правильное поведение из 0.2.3
