### PR TITLE
Add tests for bh-server and bh-server-include techs

### DIFF
--- a/test/techs/bh-server-include.test.js
+++ b/test/techs/bh-server-include.test.js
@@ -1,0 +1,256 @@
+var fs = require('fs'),
+    mock = require('mock-fs'),
+    TestNode = require('enb/lib/test/mocks/test-node'),
+    bhServerInclude = require('../../techs/bh-server-include'),
+    FileList = require('enb/lib/file-list'),
+    bhCoreFilename = require.resolve('bh/lib/bh.js');
+
+describe('bh-server-include', function () {
+    var mockBhCore = [
+        'function BH () {}',
+        'BH.prototype.apply = function() { return "^_^"; };',
+        'BH.prototype.match = function() {};',
+        'BH.prototype.setOptions = function() {};',
+        'module.exports = BH;'
+    ].join('\n');
+
+    afterEach(function () {
+        mock.restore();
+    });
+
+    it('must compile bh-file', function () {
+        var templates = [
+                'bh.match("block", function(ctx) {ctx.tag("a");});'
+            ],
+            bemjson = { block: 'block' },
+            html = '<a class="block"></a>';
+
+        return assert(bemjson, html, templates);
+    });
+
+    it('must compile bh-file with custom core', function () {
+        var templates = [
+                'bh.match("block", function(ctx) { return "Not custom core!"; });'
+            ],
+            bemjson = { block: 'block' },
+            html = '^_^',
+            options = {
+                bhFile: mockBhCore
+            };
+
+        return assert(bemjson, html, templates, options);
+    });
+
+    describe('jsAttr params', function () {
+        it('must apply default jsAttrName and jsAttrScheme params', function () {
+            var bemjson = { block: 'block', js: true },
+                html = '<div class="block i-bem" onclick="return {&quot;block&quot;:{}}"></div>';
+
+            return assert(bemjson, html);
+        });
+
+        it('must redefine jsAttrName', function () {
+            var bemjson = { block: 'block', js: true },
+                html = '<div class="block i-bem" data-bem="return {&quot;block&quot;:{}}"></div>',
+                options = { jsAttrName: 'data-bem' };
+
+            return assert(bemjson, html, null, options);
+        });
+
+        it('must redefine jsAttrScheme', function () {
+            var bemjson = { block: 'block', js: true },
+                html = '<div class="block i-bem" onclick="{&quot;block&quot;:{}}"></div>',
+                options = { jsAttrScheme: 'json' };
+
+            return assert(bemjson, html, null, options);
+        });
+    });
+
+    it('truly CommonJS', function () {
+        var templates = [
+                [
+                    'bh.match("block", function(ctx) {',
+                        'var path = require("path");',
+                        'ctx.content(path.join("fake", "path"));',
+                    '});'].join('\n')
+            ],
+            bemjson = { block: 'block' },
+            html = '<div class="block">fake/path</div>';
+
+        return assert(bemjson, html, templates);
+    });
+
+    describe('caches', function () {
+        it('must use cached bhFile', function () {
+            var scheme = {
+                    blocks: {},
+                    bundle: {}
+                },
+                bundle, fileList;
+
+            scheme[bhCoreFilename] = mock.file({
+                content: fs.readFileSync(bhCoreFilename, 'utf-8'),
+                mtime: new Date(1)
+            });
+
+            /*
+             * Добавляем кастомное ядро с mtime для проверки кэша.
+             * Если mtime кастомного ядра совпадет с mtime родного ядра,
+             * то должно быть использовано родное(закешированное).
+             */
+            scheme['mock.bh.js'] = mock.file({
+                content: mockBhCore,
+                mtime: new Date(1)
+            });
+
+            mock(scheme);
+
+            bundle = new TestNode('bundle');
+            fileList = new FileList();
+            fileList.loadFromDirSync('blocks');
+            bundle.provideTechData('?.files', fileList);
+
+            return bundle.runTech(bhServerInclude)
+                .then(function () {
+                    return bundle.runTechAndRequire(bhServerInclude, { bhFile: 'mock.bh.js' });
+                })
+                .spread(function (bh) {
+                    bh.apply({ block: 'block' }).must.be('<div class="block"></div>');
+                });
+        });
+
+        it('must rewrite cached bhFile if the new bhFile exist', function () {
+            var scheme = {
+                    blocks: {},
+                    bundle: {}
+                },
+                bundle, fileList;
+
+            scheme[bhCoreFilename] = mock.file({
+                content: fs.readFileSync(bhCoreFilename, 'utf-8'),
+                mtime: new Date(1)
+            });
+
+            /*
+             * Добавляем кастомное ядро с mtime для проверки кэша.
+             * Если mtime разные, то должно использоваться кастомное ядро
+             * (кэш должен перезаписаться)
+             */
+            scheme['mock.bh.js'] = mock.file({
+                content: mockBhCore,
+                mtime: new Date(2)
+            });
+
+            mock(scheme);
+
+            bundle = new TestNode('bundle');
+            fileList = new FileList();
+            fileList.loadFromDirSync('blocks');
+            bundle.provideTechData('?.files', fileList);
+
+            return bundle.runTech(bhServerInclude)
+                .then(function () {
+                    return bundle.runTechAndRequire(bhServerInclude, { bhFile: 'mock.bh.js' });
+                })
+                .spread(function (bh) {
+                    bh.apply({ block: 'block' }).must.be('^_^');
+                });
+        });
+
+        it('must ignore outdated cache of the templates', function () {
+            var scheme = {
+                    blocks: {
+                        'block.bh.js': bhWrap('bh.match("block", function(ctx) {ctx.tag("a");});')
+                    },
+                    bundle: {}
+                },
+                bundle, fileList;
+
+            scheme[bhCoreFilename] = fs.readFileSync(bhCoreFilename, 'utf-8');
+
+            mock(scheme);
+
+            bundle = new TestNode('bundle');
+            fileList = new FileList();
+            fileList.loadFromDirSync('blocks');
+            bundle.provideTechData('?.files', fileList);
+
+            return bundle.runTech(bhServerInclude)
+                .then(function () {
+                    fs.writeFileSync(
+                        'blocks/block.bh.js',
+                        bhWrap('bh.match("block", function(ctx) {ctx.tag("b");});')
+                    );
+
+                    fileList = new FileList();
+                    fileList.loadFromDirSync('blocks');
+                    bundle.provideTechData('?.files', fileList);
+
+                    return bundle.runTechAndRequire(bhServerInclude);
+                })
+                .spread(function (bh) {
+                    bh.apply({ block: 'block' }).must.be('<b class="block"></b>');
+                });
+        });
+    });
+
+    it('must generate sourcemap', function () {
+        var options = {
+                sourcemap: true,
+                bhFile: 'bh.js'
+            },
+            scheme = {
+                blocks: {},
+                bundle: {},
+                'bh.js': 'module.exports = BH;'
+            },
+            bundle, fileList;
+
+        mock(scheme);
+
+        bundle = new TestNode('bundle');
+        fileList = new FileList();
+        fileList.loadFromDirSync('blocks');
+        bundle.provideTechData('?.files', fileList);
+
+        return bundle.runTechAndGetContent(bhServerInclude, options)
+            .spread(function (bh) {
+                bh.toString().must.include('sourceMappingURL');
+            });
+    });
+});
+
+function bhWrap(str) {
+    return 'module.exports = function(bh) {' + str + '};';
+}
+
+function assert(bemjson, html, templates, options) {
+    var scheme = {
+            blocks: {},
+            bundle: {}
+        },
+        bundle, fileList;
+
+    if (options && options.bhFile) {
+        scheme['bh.js'] = options.bhFile;
+        options.bhFile = 'bh.js';
+    }
+
+    templates && templates.forEach(function (item, i) {
+        scheme.blocks['block-' + i + '.bh.js'] = bhWrap(item);
+    });
+
+    scheme[bhCoreFilename] = fs.readFileSync(bhCoreFilename, 'utf-8');
+
+    mock(scheme);
+
+    bundle = new TestNode('bundle');
+    fileList = new FileList();
+    fileList.loadFromDirSync('blocks');
+    bundle.provideTechData('?.files', fileList);
+
+    return bundle.runTechAndRequire(bhServerInclude, options)
+        .spread(function (bh) {
+            bh.apply(bemjson).must.be(html);
+        });
+}

--- a/test/techs/bh-server.test.js
+++ b/test/techs/bh-server.test.js
@@ -1,0 +1,265 @@
+var fs = require('fs'),
+    mock = require('mock-fs'),
+    TestNode = require('enb/lib/test/mocks/test-node'),
+    bhServer = require('../../techs/bh-server'),
+    FileList = require('enb/lib/file-list'),
+    bhCoreFilename = require.resolve('bh/lib/bh.js');
+
+describe('bh-server', function () {
+    var mockBhCore = [
+        'function BH () {}',
+        'BH.prototype.apply = function() { return "^_^"; };',
+        'BH.prototype.match = function() {};',
+        'BH.prototype.setOptions = function() {};',
+        'module.exports = BH;'
+    ].join('\n');
+
+    afterEach(function () {
+        mock.restore();
+    });
+
+    it('must compile bh-file', function () {
+        var templates = [
+                'bh.match("block", function(ctx) {ctx.tag("a");});'
+            ],
+            bemjson = { block: 'block' },
+            html = '<a class="block"></a>';
+
+        return assert(bemjson, html, templates);
+    });
+
+    it('must compile bh-file with custom core', function () {
+        var templates = [
+                'bh.match("block", function(ctx) { return "Not custom core!"; });'
+            ],
+            bemjson = { block: 'block' },
+            html = '^_^',
+            options = {
+                bhFile: mockBhCore
+            };
+
+        return assert(bemjson, html, templates, options);
+    });
+
+    describe('jsAttr params', function () {
+        it('must apply default jsAttrName and jsAttrScheme params', function () {
+            var bemjson = { block: 'block', js: true },
+                html = '<div class="block i-bem" onclick="return {&quot;block&quot;:{}}"></div>';
+
+            return assert(bemjson, html);
+        });
+
+        it('must redefine jsAttrName', function () {
+            var bemjson = { block: 'block', js: true },
+                html = '<div class="block i-bem" data-bem="return {&quot;block&quot;:{}}"></div>',
+                options = { jsAttrName: 'data-bem' };
+
+            return assert(bemjson, html, null, options);
+        });
+
+        it('must redefine jsAttrScheme', function () {
+            var bemjson = { block: 'block', js: true },
+                html = '<div class="block i-bem" onclick="{&quot;block&quot;:{}}"></div>',
+                options = { jsAttrScheme: 'json' };
+
+            return assert(bemjson, html, null, options);
+        });
+    });
+
+    describe('CommonJS', function () {
+        it('truly CommonJS', function () {
+            var templates = [
+                    [
+                        'bh.match("block", function(ctx) {',
+                            'var path = require("path");',
+                            'ctx.content(path.join("fake", "path"));',
+                        '});'
+                    ].join('\n')
+                ],
+                bemjson = { block: 'block' },
+                html = '<div class="block">fake/path</div>';
+
+            return assert(bemjson, html, templates);
+        });
+
+        it('must correctly resolve path', function () {
+            var template = [
+                        'bh.match("block", function(ctx) {',
+                            'var someModule = require("./someModule");',
+                            'ctx.content(someModule());',
+                        '});'
+                    ].join('\n'),
+                scheme = {
+                    blocks: {
+                        'block.bh.js': bhWrap(template),
+                        'someModule.js': 'module.exports = function () { return "^_^" };'
+                    },
+                    bundle: {}
+                },
+                bundle, fileList;
+
+            scheme[bhCoreFilename] = fs.readFileSync(bhCoreFilename, 'utf-8');
+
+            mock(scheme);
+
+            bundle = new TestNode('bundle');
+            fileList = new FileList();
+            fileList.loadFromDirSync('blocks');
+            bundle.provideTechData('?.files', fileList);
+
+            return bundle.runTechAndRequire(bhServer)
+                .spread(function (bh) {
+                    bh.apply({ block: 'block' }).must.be('<div class="block">^_^</div>');
+                });
+        });
+    });
+
+    describe('caches', function () {
+        it('must use cached bhFile', function () {
+            var scheme = {
+                    blocks: {},
+                    bundle: {}
+                },
+                bundle, fileList;
+
+            scheme[bhCoreFilename] = mock.file({
+                content: fs.readFileSync(bhCoreFilename, 'utf-8'),
+                mtime: new Date(1)
+            });
+
+            /*
+             * Добавляем кастомное ядро с mtime для проверки кэша.
+             * Если mtime кастомного ядра совпадет с mtime родного ядра,
+             * то должно быть использовано родное(закешированное).
+             */
+            scheme['mock.bh.js'] = mock.file({
+                content: mockBhCore,
+                mtime: new Date(1)
+            });
+
+            mock(scheme);
+
+            bundle = new TestNode('bundle');
+            fileList = new FileList();
+            fileList.loadFromDirSync('blocks');
+            bundle.provideTechData('?.files', fileList);
+
+            return bundle.runTech(bhServer)
+                .then(function () {
+                    return bundle.runTechAndRequire(bhServer, { bhFile: 'mock.bh.js' });
+                })
+                .spread(function (bh) {
+                    bh.apply({ block: 'block' }).must.be('<div class="block"></div>');
+                });
+        });
+
+        it('must rewrite cached bhFile if the new bhFile exist', function () {
+            var scheme = {
+                    blocks: {},
+                    bundle: {}
+                },
+                bundle, fileList;
+
+            scheme[bhCoreFilename] = mock.file({
+                content: fs.readFileSync(bhCoreFilename, 'utf-8'),
+                mtime: new Date(1)
+            });
+
+            /*
+             * Добавляем кастомное ядро с mtime для проверки кэша.
+             * Если mtime разные, то должно использоваться кастомное ядро
+             * (кэш должен перезаписаться)
+             */
+            scheme['mock.bh.js'] = mock.file({
+                content: mockBhCore,
+                mtime: new Date(2)
+            });
+
+            mock(scheme);
+
+            bundle = new TestNode('bundle');
+            fileList = new FileList();
+            fileList.loadFromDirSync('blocks');
+            bundle.provideTechData('?.files', fileList);
+
+            return bundle.runTech(bhServer)
+                .then(function () {
+                    return bundle.runTechAndRequire(bhServer, { bhFile: 'mock.bh.js' });
+                })
+                .spread(function (bh) {
+                    bh.apply({ block: 'block' }).must.be('^_^');
+                });
+        });
+
+        it('must ignore outdated cache of the templates', function () {
+            var scheme = {
+                    blocks: {
+                        'block.bh.js': bhWrap('bh.match("block", function(ctx) {ctx.tag("a");});')
+                    },
+                    bundle: {}
+                },
+                bundle, fileList;
+
+            scheme[bhCoreFilename] = fs.readFileSync(bhCoreFilename, 'utf-8');
+
+            mock(scheme);
+
+            bundle = new TestNode('bundle');
+            fileList = new FileList();
+            fileList.loadFromDirSync('blocks');
+            bundle.provideTechData('?.files', fileList);
+
+            return bundle.runTech(bhServer)
+                .then(function () {
+                    fs.writeFileSync(
+                        'blocks/block.bh.js',
+                        bhWrap('bh.match("block", function(ctx) {ctx.tag("b");});')
+                    );
+
+                    fileList = new FileList();
+                    fileList.loadFromDirSync('blocks');
+                    bundle.provideTechData('?.files', fileList);
+
+                    return bundle.runTechAndRequire(bhServer);
+                })
+                .spread(function (bh) {
+                    bh.apply({ block: 'block' }).must.be('<b class="block"></b>');
+                });
+        });
+    });
+});
+
+function bhWrap(str) {
+    return 'module.exports = function(bh) {' + str + '};';
+}
+
+function assert(bemjson, html, templates, options) {
+    var scheme = {
+            blocks: {},
+            bundle: {}
+        },
+        bundle, fileList;
+
+    if (options && options.bhFile) {
+        scheme['bh.js'] = options.bhFile;
+        options.bhFile = 'bh.js';
+    }
+
+    templates && templates.forEach(function (item, i) {
+        scheme.blocks['block-' + i + '.bh.js'] = bhWrap(item);
+    });
+
+    scheme[bhCoreFilename] = fs.readFileSync(bhCoreFilename, 'utf-8');
+
+    mock(scheme);
+
+    bundle = new TestNode('bundle');
+    fileList = new FileList();
+    fileList.loadFromDirSync('blocks');
+    bundle.provideTechData('?.files', fileList);
+
+    return bundle.runTechAndRequire(bhServer, options)
+        .spread(function (bh) {
+            bh.apply(bemjson).must.be(html);
+        });
+}


### PR DESCRIPTION
 По замечаниям из #32 :
- Добавил тест, проверяющий дефолтные значения `jsAttr`
- Удалил `blocks` в тестах для кешей (добавил комментарии для происходящего)
- Переименовал `core.bh.js` --> `mock.bh.js`
- Немного соптимизировал тесты
- Добавил тесты про 'Мёртвый кэш' и 'Честный CommonJS'

**IMPORTANT**: тут тесты не собираются, т.к. нет инфраструктуры