### PR TITLE
Updated CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+coverage

--- a/.jscs.js
+++ b/.jscs.js
@@ -1,6 +1,7 @@
 module.exports = {
     excludeFiles: [
-        'node_modules/**'
+        'node_modules',
+        'coverage'
     ],
     requireSpaceAfterKeywords: ['if', 'else', 'for', 'while', 'do', 'switch', 'return', 'try', 'catch'],
     requireSpaceBeforeBlockStatements: true,

--- a/.jshintignore
+++ b/.jshintignore
@@ -1,1 +1,2 @@
 node_modules
+coverage

--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,3 @@
 .*
 node_modules
+coverage

--- a/.npmignore
+++ b/.npmignore
@@ -2,3 +2,4 @@
 node_modules
 test
 coverage
+appveyor.yml

--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,4 @@
 .*
 node_modules
+test
 coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+sudo: false
+
 language: node_js
 
 node_js:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,12 @@ sudo: false
 
 language: node_js
 
-node_js:
-  - "0.10"
-  - "0.12"
-  - iojs-v1
+matrix:
+  include:
+    - node_js: iojs-v1
+    - node_js: "0.10"
+    - node_js: "0.12"
+      env: COVERALLS=1
+
+after_success:
+  - if [ "x$COVERALLS" = "x1" ]; then npm run coveralls; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,5 @@ language: node_js
 
 node_js:
   - "0.10"
+  - "0.12"
+  - iojs-v1

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 enb-bh
 ======
 
-[![NPM version](https://img.shields.io/npm/v/enb-bh.svg?style=flat)](http://badge.fury.io/js/enb-bh) [![Build Status](https://img.shields.io/travis/enb-bem/enb-bh/master.svg?style=flat)](https://travis-ci.org/enb-bem/enb-bh) [![Dependency Status](https://img.shields.io/david/enb-bem/enb-bh.svg?style=flat)](https://david-dm.org/enb-bem/enb-bh)
+[![NPM version](https://img.shields.io/npm/v/enb-bh.svg?style=flat)](https://www.npmjs.org/package/enb-bh) [![Build Status](https://img.shields.io/travis/enb-bem/enb-bh/master.svg?style=flat&label=tests)](https://travis-ci.org/enb-bem/enb-bh) [![Build status](https://img.shields.io/appveyor/ci/blond/enb-bh.svg?style=flat&label=windows)](https://ci.appveyor.com/project/blond/enb-bh) [![Coverage Status](https://img.shields.io/coveralls/enb-bem/enb-bh.svg?style=flat)](https://coveralls.io/r/enb-bem/enb-bh?branch=master) [![Dependency Status](https://img.shields.io/david/enb-bem/enb-bh.svg?style=flat)](https://david-dm.org/enb-bem/enb-bh)
 
 Поддержка [`bh`](https://github.com/enb-make/bh) для ENB.
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,18 @@
+version: "{build}"
+
+environment:
+  nodejs_version: "0.12"
+
+matrix:
+  fast_finish: true
+
+install:
+  - ps: Install-Product node $env:nodejs_version
+  - node --version
+  - npm --version
+  - npm install
+
+test_script:
+  - npm run unit
+
+build: off

--- a/package.json
+++ b/package.json
@@ -56,6 +56,6 @@
   "scripts": {
     "test": "npm run lint && npm run unit",
     "lint": "jshint . && jscs -c .jscs.js .",
-    "unit": "mocha --no-timeouts"
+    "unit": "mocha"
   }
 }

--- a/package.json
+++ b/package.json
@@ -56,6 +56,6 @@
   "scripts": {
     "test": "npm run lint && npm run unit",
     "lint": "jshint . && jscs -c .jscs.js .",
-    "unit": "mocha test/techs/*.test.js --no-timeouts"
+    "unit": "mocha --no-timeouts"
   }
 }

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   "scripts": {
     "test": "npm run lint && npm run unit",
     "lint": "jshint . && jscs -c .jscs.js .",
-    "unit": "mocha",
+    "unit": "mocha -R spec",
     "cover": "istanbul cover _mocha",
     "coveralls": "npm i coveralls && npm run cover -- --report lcovonly && cat ./coverage/lcov.info | coveralls"
   }

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "test": "npm run lint && npm run unit",
     "lint": "jshint . && jscs -c .jscs.js .",
     "unit": "mocha",
-    "cover": "istanbul cover _mocha"
+    "cover": "istanbul cover _mocha",
+    "coveralls": "npm i coveralls && npm run cover -- --report lcovonly && cat ./coverage/lcov.info | coveralls"
   }
 }

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "chai": "2.3.0",
     "enb": ">= 0.12.0 < 1.0.0",
     "finalhandler": "0.3.5",
+    "istanbul": "0.3.13",
     "jscs": "1.13.1",
     "jshint": "2.7.0",
     "mocha": "2.2.4",
@@ -56,6 +57,7 @@
   "scripts": {
     "test": "npm run lint && npm run unit",
     "lint": "jshint . && jscs -c .jscs.js .",
-    "unit": "mocha"
+    "unit": "mocha",
+    "cover": "istanbul cover _mocha"
   }
 }

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,3 +1,4 @@
+test/**/*.test.js
 --ui bdd
 --reporter spec
 --require must

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,5 +1,5 @@
 test/**/*.test.js
 --ui bdd
---reporter spec
+--reporter dot
 --require must
 --no-timeouts

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -2,3 +2,4 @@ test/**/*.test.js
 --ui bdd
 --reporter spec
 --require must
+--no-timeouts


### PR DESCRIPTION
**Tests**

* Added `test` to `.npmignore`
* Mocha: run all tests by default
* Mocha: run tests with `--no-timeouts` by default
* Mocha: use `dot` reporter by default
* Mocha: use `spec` reporter for tests

**Travis**

* Speed up builds by using Docker-based Travis CI
* Run tests in `node@0.12` and `io.js@1.0`

**Coverage**

* Added coverage
* Travis: run coveralls only in Node.js@0.12 and after success

**Windows**

* Use AppVeyor for run tests in Windows (only Node.js@0.12)

**Badges**

* Updated url to npm
* Renamed travis to tests
* Added windows
* Added coverage
