### PR TITLE
Got rid of the possibility to replace of BH core

### DIFF
--- a/lib/compile.js
+++ b/lib/compile.js
@@ -1,5 +1,11 @@
-var File = require('enb-source-map/lib/file'),
-    EOL = require('os').EOL;
+var fs = require('fs'),
+    File = require('enb-source-map/lib/file'),
+    EOL = require('os').EOL,
+    core = {};
+
+// Read File with BH core
+core.path = require.resolve('bh/lib/bh.js');
+core.contents = fs.readFileSync(core.path, 'utf-8');
 
 /**
  * Compile code of bh module with core and source templates.
@@ -7,9 +13,6 @@ var File = require('enb-source-map/lib/file'),
  * The compiled BH module supports CommonJS and YModules. If there is no any modular system in the runtime,
  * the module will be provided as global variable `BH`.
  *
- * @param {Object}   core          File with bh core
- * @param {String}   core.path     Path to file with BH core
- * @param {String}   core.contents Contents of file with BH core
  * @param {{path: String, contents: String}[]} sources Files with source templates
  * @param {Object}   opts
  * @param {String}   opts.filename          Path to compiled file
@@ -21,7 +24,7 @@ var File = require('enb-source-map/lib/file'),
  * @param {Object}   [opts.dependencies]    Names for requires to `BH.lib.name`
  * @returns {String} compiled code of bh module
  */
-function compile(core, sources, opts) {
+function compile(sources, opts) {
     opts || (opts = {});
 
     /* istanbul ignore if */

--- a/techs/bh-commonjs.js
+++ b/techs/bh-commonjs.js
@@ -31,28 +31,20 @@
  * ```
  */
 
-var path = require('path');
+var coreFilename = require.resolve('bh/lib/bh.js');
 
 module.exports = require('enb/lib/build-flow').create()
     .name('bh-commonjs')
     .target('target', '?.bh.js')
-    .defineOption('bhFile', '')
     .defineOption('mimic', [])
     .defineOption('jsAttrName', 'data-bem')
     .defineOption('jsAttrScheme', 'json')
     .defineOption('jsCls', 'i-bem')
     .defineOption('escapeContent', false)
     .useFileList(['bh.js'])
-    .needRebuild(function (cache) {
-        this._bhFile = this._bhFile ? path.join(this.node._root, this._bhFile) : require.resolve('bh/lib/bh.js');
-
-        return cache.needRebuildFile('bh-file', this._bhFile);
-    })
-    .saveCache(function (cache) {
-        cache.cacheFileInfo('bh-file', this._bhFile);
-    })
     .builder(function (bhFiles) {
         var node = this.node;
+
         /**
          * Генерирует `require`-строку для подключения исходных bh-файлов.
          *
@@ -96,7 +88,7 @@ module.exports = require('enb/lib/build-flow').create()
 
         return [
             dropRequireCacheFunc,
-            buildRequire(this._bhFile, 'var BH = '),
+            buildRequire(coreFilename, 'var BH = '),
             'var bh = new BH();',
             'bh.setOptions({',
             '   jsAttrName: \'' + this._jsAttrName + '\',',

--- a/test/techs/bh-bundle/bh-bundle.test.js
+++ b/test/techs/bh-bundle/bh-bundle.test.js
@@ -29,19 +29,6 @@ describe('bh-bundle', function () {
         return assert(bemjson, html, templates);
     });
 
-    it('must compile BH file with custom core', function () {
-        var templates = [
-                'bh.match("block", function(ctx) { return "Not custom core!"; });'
-            ],
-            bemjson = { block: 'block' },
-            html = '^_^',
-            options = {
-                bhFile: mockBhCore
-            };
-
-        return assert(bemjson, html, templates, options);
-    });
-
     describe('jsAttr params', function () {
         it('must apply default jsAttrName and jsAttrScheme params', function () {
             var bemjson = { block: 'block', js: true },
@@ -162,44 +149,6 @@ describe('bh-bundle', function () {
                 });
         });
 
-        it('must rewrite cached bhFile if the new bhFile exist', function () {
-            var scheme = {
-                    blocks: {},
-                    bundle: {}
-                },
-                bundle, fileList;
-
-            scheme[bhCoreFilename] = mock.file({
-                content: fs.readFileSync(bhCoreFilename, 'utf-8'),
-                mtime: new Date(1)
-            });
-
-            /*
-             * Добавляем кастомное ядро с mtime для проверки кэша.
-             * Если mtime разные, то должно использоваться кастомное ядро
-             * (кэш должен перезаписаться)
-             */
-            scheme['mock.bh.js'] = mock.file({
-                content: mockBhCore,
-                mtime: new Date(2)
-            });
-
-            mock(scheme);
-
-            bundle = new TestNode('bundle');
-            fileList = new FileList();
-            fileList.loadFromDirSync('blocks');
-            bundle.provideTechData('?.files', fileList);
-
-            return bundle.runTech(Tech)
-                .then(function () {
-                    return bundle.runTechAndRequire(Tech, { bhFile: 'mock.bh.js' });
-                })
-                .spread(function (bh) {
-                    bh.apply({ block: 'block' }).must.be('^_^');
-                });
-        });
-
         it('must ignore outdated cache of the templates', function () {
             var scheme = {
                     blocks: {
@@ -274,11 +223,6 @@ function assert(bemjson, html, templates, options) {
             bundle: {}
         },
         bundle, fileList;
-
-    if (options && options.bhFile) {
-        scheme['bh.js'] = options.bhFile;
-        options.bhFile = 'bh.js';
-    }
 
     templates && templates.forEach(function (item, i) {
         scheme.blocks['block-' + i + '.bh.js'] = bhWrap(item);

--- a/test/techs/bh-commonjs.test.js
+++ b/test/techs/bh-commonjs.test.js
@@ -29,19 +29,6 @@ describe('bh-commonjs', function () {
         return assert(bemjson, html, templates);
     });
 
-    it('must compile BH file with custom core', function () {
-        var templates = [
-                'bh.match("block", function(ctx) { return "Not custom core!"; });'
-            ],
-            bemjson = { block: 'block' },
-            html = '^_^',
-            options = {
-                bhFile: mockBhCore
-            };
-
-        return assert(bemjson, html, templates, options);
-    });
-
     describe('jsAttr params', function () {
         it('must apply default jsAttrName and jsAttrScheme params', function () {
             var bemjson = { block: 'block', js: true },
@@ -234,44 +221,6 @@ describe('bh-commonjs', function () {
                 });
         });
 
-        it('must rewrite cached bhFile if the new bhFile exist', function () {
-            var scheme = {
-                    blocks: {},
-                    bundle: {}
-                },
-                bundle, fileList;
-
-            scheme[bhCoreFilename] = mock.file({
-                content: fs.readFileSync(bhCoreFilename, 'utf-8'),
-                mtime: new Date(1)
-            });
-
-            /*
-             * Добавляем кастомное ядро с mtime для проверки кэша.
-             * Если mtime разные, то должно использоваться кастомное ядро
-             * (кэш должен перезаписаться)
-             */
-            scheme['mock.bh.js'] = mock.file({
-                content: mockBhCore,
-                mtime: new Date(2)
-            });
-
-            mock(scheme);
-
-            bundle = new TestNode('bundle');
-            fileList = new FileList();
-            fileList.loadFromDirSync('blocks');
-            bundle.provideTechData('?.files', fileList);
-
-            return bundle.runTech(Tech)
-                .then(function () {
-                    return bundle.runTechAndRequire(Tech, { bhFile: 'mock.bh.js' });
-                })
-                .spread(function (BH) {
-                    BH.apply({ block: 'block' }).must.be('^_^');
-                });
-        });
-
         it('must ignore outdated cache of the templates', function () {
             var scheme = {
                     blocks: {
@@ -321,11 +270,6 @@ function assert(bemjson, html, templates, options) {
             bundle: {}
         },
         bundle, fileList;
-
-    if (options && options.bhFile) {
-        scheme['bh.js'] = options.bhFile;
-        options.bhFile = 'bh.js';
-    }
 
     templates && templates.forEach(function (item, i) {
         scheme.blocks['block-' + i + '.bh.js'] = bhWrap(item);


### PR DESCRIPTION
Resolved #59 

* The `compile` module now reads the BH core
* Removed `bhFile` option
* Removed tests with `bhFile` option